### PR TITLE
Fix server resolution on xml single server definition

### DIFF
--- a/index.js
+++ b/index.js
@@ -10,7 +10,8 @@ var fetch = exports.fetch = function(callback) {
 
   parseString(xmlData, {explicitArray: false}, function (err, xml) {
 
-    var server = (xml.settings.servers.server[0] || xml.settings.servers.server);
+    var servers = xml.settings.servers;
+    var server = (servers.server[0] || servers.server);
     credentials.username = server.username;
     credentials.password = server.password;
 

--- a/index.js
+++ b/index.js
@@ -6,12 +6,13 @@ var path = require('path'),
 var fetch = exports.fetch = function(callback) {
 
   var credentials = {};
-  var xmlData = fs.readFileSync(path.join(osenv.home(), '.m2') + '/settings.xml');//, function(err, data) {
+  var xmlData = fs.readFileSync(path.join(osenv.home(), '.m2') + '/settings.xml');
 
   parseString(xmlData, {explicitArray: false}, function (err, xml) {
 
-    credentials.username = xml.settings.servers.server[0].username;
-    credentials.password = xml.settings.servers.server[0].password;
+    var server = (xml.settings.servers.server[0] || xml.settings.servers.server);
+    credentials.username = server.username;
+    credentials.password = server.password;
 
   });
 


### PR DESCRIPTION
When the user has only one server definition the resolution fails, so it should check if it has more than one server definitions or not before resolve the user and password.
